### PR TITLE
alternative cache implementation

### DIFF
--- a/src/main/kotlin/dev/echonine/kite/Kite.kt
+++ b/src/main/kotlin/dev/echonine/kite/Kite.kt
@@ -43,7 +43,7 @@ class Kite : JavaPlugin() {
             }
         }
         // Bump this if cache is no longer compatible between releases.
-        const val CACHE_VERSION = "1"
+        const val CACHE_VERSION = "2"
     }
 
     override fun onEnable() {

--- a/src/main/kotlin/dev/echonine/kite/scripting/ScriptManager.kt
+++ b/src/main/kotlin/dev/echonine/kite/scripting/ScriptManager.kt
@@ -137,7 +137,7 @@ internal class ScriptManager(val plugin: Kite) {
         }
         // Compiling/loading the script. Measure operation time to verify cache performance.
         val (compiledScript, elapsedTime) = measureTimedValue {
-            scriptingHost.eval(holder.entryPoint.toScriptSource(), compilationConfiguration, evaluationConfiguration)
+            scriptingHost.eval(FileScriptSource(holder.entryPoint), compilationConfiguration, evaluationConfiguration)
         }
         // Logging message after *failed* compilation, but before diagnostics.
         if (compiledScript is ResultWithDiagnostics.Failure) {

--- a/src/main/kotlin/dev/echonine/kite/scripting/cache/ImportsCache.kt
+++ b/src/main/kotlin/dev/echonine/kite/scripting/cache/ImportsCache.kt
@@ -6,51 +6,53 @@ import dev.echonine.kite.Kite
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
-typealias DependencyTree = MutableMap<String, MutableSet<String>>
-
 class ImportsCache {
     private val mutex = Mutex()
     private val gson = GsonBuilder().setPrettyPrinting().create()
-    private val file = Kite.Structure.CACHE_DIR.resolve(".imports")
+    private val directory = Kite.Structure.CACHE_DIR.resolve("imports")
 
-    private val typeToken = object : TypeToken<DependencyTree>() { /* TYPE MARKER */ }
-
-    var cache: DependencyTree = mutableMapOf()
-        private set
-
-    init {
-        // Creating parent directories and file in case it does not exist.
-        file.parentFile.mkdirs()
-        file.createNewFile()
-        // Reading file contents.
-        cache = file.bufferedReader().use { gson.fromJson(it, typeToken) } ?: mutableMapOf()
-    }
+    private val typeToken = object : TypeToken<MutableSet<String>>() {}
 
     suspend fun invalidate(name: String) = mutex.withLock {
-        cache.remove(name)
-        // Saving contents to the file.
-        this.save()
+        directory.resolve("$name.json").delete()
     }
 
-    suspend fun append(name: String, dependencies: Collection<String>) = mutex.withLock {
-        // Putting list of dependencies / imports in the map.
-        cache.computeIfAbsent(name) { mutableSetOf() }.addAll(dependencies)
+    suspend fun append(name: String, dependencies: Collection<String>) {
         // Saving contents to the file.
-        this.save()
-    }
-
-    private fun save() {
+        val contents = this.read(name)
+        // Updating contents.
+        contents.addAll(dependencies)
         // Creating parent directories and file in case it does not exist.
-        file.parentFile.mkdirs()
-        file.createNewFile()
-        // Saving contents to the file.
-        file.bufferedWriter().use {
-            try {
-                gson.toJson(cache, typeToken.type, it)
-            } catch (e: Throwable) {
-                e.printStackTrace()
+        val file = directory.resolve("$name.json").also {
+            it.parentFile.mkdirs()
+            it.createNewFile()
+        }
+        // Writing to the file...By using Mutex here, we ensure writes are synchronized.
+        mutex.withLock {
+            file.bufferedWriter().use {
+                try {
+                    gson.toJson(contents, typeToken.type, it)
+                } catch (e: Throwable) {
+                    e.printStackTrace()
+                }
             }
         }
+    }
+
+    suspend fun read(name: String): MutableSet<String> = mutex.withLock {
+        // Creating parent directories and file in case it does not exist.
+        val file = directory.resolve("$name.json").also {
+            it.parentFile.mkdirs()
+            it.createNewFile()
+        }
+        return file.bufferedReader().use {
+            try {
+                gson.fromJson(it, typeToken.type) as? MutableSet<String>
+            } catch (e: Throwable) {
+                e.printStackTrace()
+                return@use null
+            }
+        } ?: mutableSetOf()
     }
 
 }

--- a/src/main/kotlin/dev/echonine/kite/scripting/cache/ImportsCache.kt
+++ b/src/main/kotlin/dev/echonine/kite/scripting/cache/ImportsCache.kt
@@ -9,12 +9,10 @@ import kotlinx.coroutines.sync.withLock
 class ImportsCache {
     private val mutex = Mutex()
     private val gson = GsonBuilder().setPrettyPrinting().create()
-    private val directory = Kite.Structure.CACHE_DIR.resolve("imports")
-
     private val typeToken = object : TypeToken<MutableSet<String>>() {}
 
     suspend fun invalidate(name: String) = mutex.withLock {
-        directory.resolve("$name.json").delete()
+        Kite.Structure.CACHE_DIR.resolve("$name/imports.json").delete()
     }
 
     suspend fun append(name: String, dependencies: Collection<String>) {
@@ -23,7 +21,7 @@ class ImportsCache {
         // Updating contents.
         contents.addAll(dependencies)
         // Creating parent directories and file in case it does not exist.
-        val file = directory.resolve("$name.json").also {
+        val file = Kite.Structure.CACHE_DIR.resolve("$name/imports.json").also {
             it.parentFile.mkdirs()
             it.createNewFile()
         }
@@ -41,7 +39,7 @@ class ImportsCache {
 
     suspend fun read(name: String): MutableSet<String> = mutex.withLock {
         // Creating parent directories and file in case it does not exist.
-        val file = directory.resolve("$name.json").also {
+        val file = Kite.Structure.CACHE_DIR.resolve("$name/imports.json").also {
             it.parentFile.mkdirs()
             it.createNewFile()
         }

--- a/src/main/kotlin/dev/echonine/kite/scripting/configuration/KiteCompilationConfiguration.kt
+++ b/src/main/kotlin/dev/echonine/kite/scripting/configuration/KiteCompilationConfiguration.kt
@@ -117,10 +117,12 @@ object KiteCompilationConfiguration : ScriptCompilationConfiguration({
                     .build()
             }
             // Collecting other .kite.kts files referenced via @Import and adding to an imported sources list.
-            annotations.filterIsInstance<Import>().forEach {
-                it.paths.forEach { path ->
-                    importedSources += FileScriptSource(scriptBaseDir?.resolve(path)?.canonicalFile ?: File(path))
-                }
+            annotations.filterIsInstance<Import>().forEach { aImport ->
+                aImport.paths.map {
+                    val file = scriptBaseDir?.resolve(it)?.canonicalFile ?: File(it)
+                    // We cannot return directory here as it can break the cache until manually removed.
+                    return@map if (file.isDirectory) file.resolve("main.kite.kts") else file
+                }.filter { it.exists() && it.isFile }.forEach { importedSources += FileScriptSource(it) }
             }
             return@onAnnotations ScriptCompilationConfiguration(context.compilationConfiguration) {
                 runBlocking {
@@ -134,6 +136,7 @@ object KiteCompilationConfiguration : ScriptCompilationConfiguration({
                         dependencies.append(JvmDependency(libraryManager.resolvedPaths.toList()))
                 }
                 // Appending imported sources to the script.
+                println("importScripts#append: $importedSources")
                 importedSources.takeUnless { it.isEmpty() }?.let { importScripts.append(it) }
             }.asSuccess()
         })
@@ -155,8 +158,10 @@ object KiteCompilationConfiguration : ScriptCompilationConfiguration({
                 // MD5 checksum acts as a file identifier here.
                 checksum.update(script.text.toByteArray())
                 // Updating digest with all imported scripts.
-                Kite.IMPORTS_CACHE?.cache[name]?.map { File(it) }?.filter { it.exists() }?.forEach {
-                    checksum.update(it.readBytes())
+                runBlocking {
+                    Kite.IMPORTS_CACHE?.read(name!!)?.map { File(it) }?.filter { it.exists() && it.isFile }?.forEach {
+                        checksum.update(it.readBytes())
+                    }
                 }
                 // Updating digest with the current cache version.
                 checksum.update(Kite.Environment.CACHE_VERSION.toByteArray())

--- a/src/main/kotlin/dev/echonine/kite/scripting/configuration/KiteCompilationConfiguration.kt
+++ b/src/main/kotlin/dev/echonine/kite/scripting/configuration/KiteCompilationConfiguration.kt
@@ -118,11 +118,9 @@ object KiteCompilationConfiguration : ScriptCompilationConfiguration({
             }
             // Collecting other .kite.kts files referenced via @Import and adding to an imported sources list.
             annotations.filterIsInstance<Import>().forEach { aImport ->
-                aImport.paths.map {
-                    val file = scriptBaseDir?.resolve(it)?.canonicalFile ?: File(it)
-                    // We cannot return directory here as it can break the cache until manually removed.
-                    return@map if (file.isDirectory) file.resolve("main.kite.kts") else file
-                }.filter { it.exists() && it.isFile }.forEach { importedSources += FileScriptSource(it) }
+                aImport.paths.map { scriptBaseDir?.resolve(it)?.canonicalFile ?: File(it) }.forEach {
+                    importedSources += FileScriptSource(it)
+                }
             }
             return@onAnnotations ScriptCompilationConfiguration(context.compilationConfiguration) {
                 runBlocking {
@@ -136,7 +134,6 @@ object KiteCompilationConfiguration : ScriptCompilationConfiguration({
                         dependencies.append(JvmDependency(libraryManager.resolvedPaths.toList()))
                 }
                 // Appending imported sources to the script.
-                println("importScripts#append: $importedSources")
                 importedSources.takeUnless { it.isEmpty() }?.let { importScripts.append(it) }
             }.asSuccess()
         })
@@ -151,7 +148,7 @@ object KiteCompilationConfiguration : ScriptCompilationConfiguration({
             compilationCache(CompiledScriptJarsCache { script, compilationConfiguration ->
                 // Creating cache directory in case it does not exist.
                 Kite.Structure.CACHE_DIR.mkdirs()
-                // Creating directories in case they don't exist yet.
+                // Getting name of the script.
                 val name = compilationConfiguration[displayName]
                 val checksum = MessageDigest.getInstance("MD5")
                 // Getting the MD5 checksum and including it in the file name.
@@ -167,11 +164,12 @@ object KiteCompilationConfiguration : ScriptCompilationConfiguration({
                 checksum.update(Kite.Environment.CACHE_VERSION.toByteArray())
                 // Converting checksum to a human-readable format so it can be included in the cache file name.
                 val hash = checksum.digest().joinToString("") { "%02x".format(it) }
-                val file = Kite.Structure.CACHE_DIR.resolve("$name.$hash.cache.jar")
+                val file = Kite.Structure.CACHE_DIR.resolve("$name/$hash.cache.jar")
                 // Purging old cache files with different hashes (not the current one).
-                Kite.Structure.CACHE_DIR.listFiles()
-                    ?.filter { it.name.endsWith(".cache.jar") && it.name.split(".").first() == name && it.name != file.name }
-                    ?.forEach { it.delete() }
+                Kite.Structure.CACHE_DIR.resolve(name!!).listFiles().forEach {
+                    if (it.name.endsWith(".cache.jar") && it.name != file.name)
+                        it.delete()
+                }
                 // Returning the file that should hold the script cache.
                 return@CompiledScriptJarsCache file
             })


### PR DESCRIPTION
Instead of using one `.imports` file storing imports of all scripts - which proved to be problematic - this implementation maintains cache file for each script individually.

I'm unable to test *all* race conditions but I tested for ones I know were occurring with old implementation.
Everything seems to work as expected.

### File Structure
```
Kite/
  cache/
    (script)/
      imports.json
      (hash).cache.jar
  scripts/
     ...
```
