### PR TITLE
fix remote dependencies being inaccessible at runtime

### DIFF
--- a/src/main/kotlin/dev/echonine/kite/Kite.kt
+++ b/src/main/kotlin/dev/echonine/kite/Kite.kt
@@ -48,7 +48,7 @@ class Kite : JavaPlugin(), Listener {
             }
         }
         // Bump this if cache is no longer compatible between releases.
-        const val CACHE_VERSION = "3"
+        const val CACHE_VERSION = "4"
     }
 
     override fun onEnable() {

--- a/src/main/kotlin/dev/echonine/kite/scripting/ScriptManager.kt
+++ b/src/main/kotlin/dev/echonine/kite/scripting/ScriptManager.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger
 import org.jetbrains.annotations.Unmodifiable
+import java.net.URLClassLoader
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.resume
 import kotlin.script.experimental.api.ResultWithDiagnostics
@@ -123,10 +124,16 @@ internal class ScriptManager(val plugin: Kite) {
                 }
             }
         }
+        // Building a classloader that includes any JARs downloaded into the per-script libs directory.
+        val dependencies = Kite.Structure.CACHE_DIR.resolve(script.name).resolve("libs").walkTopDown()
+            .filter { it.isFile && it.extension == "jar" }
+            .map { it.toURI().toURL() }
+            .toList()
+        val classLoader = if (dependencies.isEmpty() == false) URLClassLoader(dependencies.toTypedArray(), Kite::class.java.classLoader) else Kite::class.java.classLoader
         // Creating EvaluationConfiguration based on KiteEvaluationConfiguration template.
         val evaluationConfiguration = KiteEvaluationConfiguration.with {
             jvm {
-                baseClassLoader(Kite::class.java.classLoader)
+                baseClassLoader(classLoader)
             }
             implicitReceivers(script)
             providedProperties(mapOf(

--- a/src/main/kotlin/dev/echonine/kite/scripting/configuration/KiteCompilationConfiguration.kt
+++ b/src/main/kotlin/dev/echonine/kite/scripting/configuration/KiteCompilationConfiguration.kt
@@ -91,9 +91,12 @@ object KiteCompilationConfiguration : ScriptCompilationConfiguration({
                 ?: return@onAnnotations context.compilationConfiguration.asSuccess()
             val scriptBaseDir = (context.script as? FileBasedScriptSource)?.file?.parentFile
             val importedSources: MutableList<FileScriptSource> = mutableListOf()
-            // We don't want to share the instance of KiteLibraryManager between compiler runs.
-            // Reason: It can easily stock up on stale repositories and dependencies.
-            val libraryManager = KiteLibraryManager()
+            val libsDirectory = Kite.Structure.CACHE_DIR.resolve("${context.compilationConfiguration[displayName]}").resolve("libs")
+            // Creating KiteLibraryManager instance. Downloads are placed in scripts' own 'plugins/Kite/cache/{SCRIPT}/libs/' directory because:
+            //   (1) this improves script isolation
+            //   (2) this does not require any extra tracking to know which dependencies should be added to runtime classpath
+            // We also don't want to share the instance of KiteLibraryManager between compiler runs. It can easily stock up on stale repositories and dependencies.
+            val libraryManager = KiteLibraryManager(libsDirectory)
             // Adding all declared repositories to the KiteLibraryManager instance.
             annotations.filterIsInstance<Repository>().map { it.repository }.forEach(libraryManager::addRepository)
             // Getting declared @Dependency and @Relocation annotations.

--- a/src/main/kotlin/dev/echonine/kite/scripting/libraries/KiteLibraryManager.kt
+++ b/src/main/kotlin/dev/echonine/kite/scripting/libraries/KiteLibraryManager.kt
@@ -34,7 +34,7 @@ private class SoftLogAdapter(logger: Logger) : JDKLogAdapter(logger) {
 
 // This class is based on BukkitLibraryLoader and exists solely to track resolved dependencies.
 // Neither LibraryLoader#downloadLibrary nor LibraryLoader#loadLibrary do not return a comprehensive list of resolved dependencies.
-class KiteLibraryManager : LibraryManager(SoftLogAdapter(Kite.INSTANCE!!.logger), Kite.Structure.KITE_DIR.toPath(), Kite.Structure.LIBS_DIR.name) {
+class KiteLibraryManager(libsDirectory: File) : LibraryManager(SoftLogAdapter(Kite.INSTANCE!!.logger), libsDirectory.parentFile.toPath(), libsDirectory.name) {
     val resolvedPaths = ConcurrentHashMap.newKeySet<File>()!!
 
     // See that super method is not called here.


### PR DESCRIPTION
*(Copied from Discord)*

There seems to be an issue with dependency loader occasionally breaking.

**Reproduction:**
1. Download [service.zip](https://github.com/user-attachments/files/28272172/service.zip) test script
1. Unarchive and put `service` directory in `plugins/Kite/scripts`
2. Restart the server until dependency is non-resolvable: `NoClassDefFoundError: kong/unirest/core/Unirest`

**Additional Notes:**
- ~~When this happens, script will refuse to be reloaded.~~ (Unrelated and fixed in 4155c76bac1bb8b551cc26f8ada684b8c2eb522e)
  - ~~With /kite reloadall, it'll block the chain as soon as problematic script is attempted to be reloaded.~~
  - ~~What seems to cause that is that exception is thrown during runOnUnload, should be an easy fix.~~
- When it gets to a working state, next restart will break it again even though cache was reused.

This PR fixes that, at least without any immediate side-effect, but I'm not 100% confident it is a proper way.

- Libraries are now downloaded for each script separately and they are placed in `plugins/Kite/cache/libs/` directory.
  - All of these libs will be appended to runtime classpath and issue with that is, stale dependencies could mess with the result. If behavior is to be kept, it should be documented. Resetting the cache will of course re-download only ones that are defined, so it has a simple manual fix.
- Libraries directory at `plugins/Kite/libs/` will be only used for local `.jar` dependencies.

*Ideally, in the future we write our own, internal (transitive) library resolver so we can make it as flexible as it needs to be. Libby is less annoying than Zapper but it's still lacking what we need. Kinda expected as boths libs were made with a different purpose in mind.*

*Or maybe we get around fixing JetBrains' impl built-in for `@DependsOn` but good luck with this one given it's not very well documented.*