### PR TITLE
fix incorrect server environment check

### DIFF
--- a/src/main/kotlin/dev/echonine/kite/Kite.kt
+++ b/src/main/kotlin/dev/echonine/kite/Kite.kt
@@ -40,13 +40,6 @@ class Kite : JavaPlugin(), Listener {
     }
 
     object Environment {
-        val IS_SERVER_AVAILABLE by lazy {
-            try {
-                return@lazy Class.forName("org.bukkit.Server") != null
-            } catch (e: ClassNotFoundException) {
-                return@lazy false
-            }
-        }
         // Bump this if cache is no longer compatible between releases.
         const val CACHE_VERSION = "4"
     }

--- a/src/main/kotlin/dev/echonine/kite/scripting/configuration/KiteCompilationConfiguration.kt
+++ b/src/main/kotlin/dev/echonine/kite/scripting/configuration/KiteCompilationConfiguration.kt
@@ -82,7 +82,7 @@ object KiteCompilationConfiguration : ScriptCompilationConfiguration({
         onAnnotations(Import::class, Dependency::class, Repository::class, Relocation::class, handler = { context ->
             // Skipping Kite annotation processor if running outside of server context.
             // At this time, these annotations cannot be easily instructed to work inside IDEA due to technical limitations.
-            if (!Kite.Environment.IS_SERVER_AVAILABLE)
+            if (Kite.INSTANCE == null)
                 return@onAnnotations context.compilationConfiguration.asSuccess()
             // Collecting all defined annotations.
             val annotations = context.collectedData?.get(ScriptCollectedData.collectedAnnotations)


### PR DESCRIPTION
This properly prevents annotations from being processed inside IDEA.

Fixes annotations breaking enhanced language features on IntelliJ IDEA 2026.2.
This was also happening on 2026.1 but occasionally and inconsistently. 

Proper annotations support will be added in a future PR.